### PR TITLE
Add publishing cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ channel.subscribe('metrics.#', function (topic, msg) {
 channel.publish('metrics.page.loaded', 'hello world');
 ```
 
+### How it works
+
+A Bus builds a directed graph of subscriptions.  As event topics are published, the graph discovers all the subscribers that should be notified and the results are cached for faster message publishing in the future.  When a new subscriber is added, the graph is modified and the cache is reset.
+
 ### Wildcard subscriptions
 
 Supports same wildcards as Postal.js, such as:
@@ -85,5 +89,9 @@ channel.emit('ads.slot.post-nav.filled', {data, msg});
 - [License - Apache 2.0](https://github.com/CondeNast/quick-bus/blob/master/LICENSE.md)
 - [Code of Conduct - Contributor Covenant v1.4](https://github.com/CondeNast/quick-bus/blob/master/CODE_OF_CONDUCT.md)
 - [Contributing Guidelines - Atom and Rails](https://github.com/CondeNast/quick-bus/blob/master/CONTRIBUTING.md)
+
+### Related Topics
+
+- [RabbitMX Topic Exchange tutorial explaining * and # wildcards](https://www.rabbitmq.com/tutorials/tutorial-five-javascript.html)
 
 ![Conde Nast Technology Logo](https://user-images.githubusercontent.com/4154804/34785005-e70e4326-f5fd-11e7-8ae6-759c3b0300b5.png)

--- a/index.js
+++ b/index.js
@@ -55,15 +55,24 @@ var Bus = (function () {
 
   return function Bus() {
     var head = { w: '', r: {}, i: headCount++ };
+    var emitCache = {}; // memoize graph lookups
 
     function on(topicStr, fn) {
       var lastNode = add(topicStr.split('.'), head);
       lastNode.fn = lastNode.fn || [];
       lastNode.fn.push(fn);
+      emitCache = {}; // forget graph lookups because everything has changed
     }
 
     function emit(topicStr, message) {
+      if (emitCache[topicStr]) { // use previous work if available
+        return emitCache[topicStr];
+      }
+
       var list = getList(topicStr.split('.'), head);
+
+      emitCache[topicStr] = list; // remember previous work
+
       for (var i = 0; i < list.length; i++) {
         var fn = list[i];
         for (var j = 0; j < fn.length; j++) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I added an internal cache for publishing events to the library, so now every publish beyond the first for any particular topic should be O(1).  The cache will be cleared when a new subscriber is added because the graph will be changed. (edited)

So yeah, we should use this for metrics.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context

Before, each publish was doing a graph lookup, even if the number of events being generated is low.

## How Has This Been Tested?

I passed the code into a browser and inspected the internals.

Also, all the original unit tests pass.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
