### PR TITLE
unsubscribe

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ channel.on('metrics.#', function (topic, msg) {
 channel.emit('metrics.page.loaded', 'hello world');
 ```
 
+In imitation of Postal.js, use the returned function to stop the events.
+
+```js
+var off = channel.on('page.load.justOnce', function (topic, msg) {
+  console.log(topic, msg);
+  off();
+});
+```
+
 If you like the pub/sub model better, we've aliased `subscribe` and `publish` as well:
 
 ```js
@@ -42,6 +51,20 @@ channel.subscribe('metrics.#', function (topic, msg) {
 });
 
 channel.publish('metrics.page.loaded', 'hello world');
+```
+
+And of course to unsubscribe, use the returned function:
+
+```js
+var unsubscribe = channel.subscribe('#', function (topic, msg) {
+  console.log(Date.now(), topic, msg);
+});
+
+for (var i = 0; i < 10; i++) {
+  channel.publish('welcome.' + i, 'hello world!');
+}
+
+unsubscribe();
 ```
 
 ### How it works

--- a/index.js
+++ b/index.js
@@ -114,9 +114,18 @@ var Bus = (function () {
 
     function on(topicStr, fn) {
       var lastNode = add(topicStr.split('.'), head);
-      lastNode.fn = lastNode.fn || [];
-      lastNode.fn.push(fn);
+      var fnList = lastNode.fn || [];
+      fnList.push(fn);
+      lastNode.fn = fnList;
       emitCache = {}; // forget graph lookups because everything has changed
+
+      // return off() function to unsubscribe
+      return function () {
+        var index = fnList.indexOf(fn);
+        if (index > -1) {
+          fnList.splice(index, 1);
+        }
+      }
     }
 
     function emit(topicStr, message) {

--- a/index.test.js
+++ b/index.test.js
@@ -260,6 +260,81 @@ describe('wildstar #', function () {
   });
 });
 
+describe('unsubscribe', function () {
+  it('does not receive exact match after unsubscribe', function () {
+    var bus = new Bus();
+    var spy = sinon.spy();
+
+    var off = bus.on('a', spy);
+    off();
+    bus.emit('a');
+
+    sinon.assert.notCalled(spy);
+  });
+
+  it('does not receive wildcard a.* match after unsubscribe', function () {
+    var bus = new Bus();
+    var spy = sinon.spy();
+
+    var off = bus.on('a.*', spy);
+    off();
+    bus.emit('a.b');
+
+    sinon.assert.notCalled(spy);
+  });
+
+  it('does not receive wildcard *.a match after unsubscribe', function () {
+    var bus = new Bus();
+    var spy = sinon.spy();
+
+    var off = bus.on('*.b', spy);
+    off();
+    bus.emit('a.b');
+
+    sinon.assert.notCalled(spy);
+  });
+
+  it('does not receive wildcard a.# match after unsubscribe', function () {
+    var bus = new Bus();
+    var spy = sinon.spy();
+
+    var off = bus.on('a.#', spy);
+    off();
+    bus.emit('a.b');
+
+    sinon.assert.notCalled(spy);
+  });
+
+  it('does not receive wildcard #.a match after unsubscribe', function () {
+    var bus = new Bus();
+    var spy = sinon.spy();
+
+    var off = bus.on('#.b', spy);
+    off();
+    bus.emit('a.b');
+
+    sinon.assert.notCalled(spy);
+  });
+
+  it('does not receive wildcard #.a match with multiple subscribers after single unsubscribe', function () {
+    var bus = new Bus();
+    var spy1 = sinon.spy();
+    var spy2 = sinon.spy();
+    var spy3 = sinon.spy();
+
+    bus.on('#.b', spy1);
+    var off = bus.on('#.b', spy2);
+    bus.on('#.b', spy3);
+    off();
+    bus.emit('a.b');
+
+    sinon.assert.called(spy1);
+    sinon.assert.notCalled(spy2);
+    sinon.assert.called(spy3);
+  });
+});
+
+
 describe('history', function () {
   it('no events and no entries gives no history', function () {
     var bus = new Bus();


### PR DESCRIPTION
Add unsubscribe feature.

## Description
Adds a new feature where we can unsubscribe from events by returning the function from `.on` or `.subscribe`.

```js
var off = channel.on('page.load.justOnce', function (topic, msg) {
  console.log(topic, msg);
  off();
});
```

```js
var unsubscribe = channel.subscribe('#', function (topic, msg) {
  console.log(Date.now(), topic, msg);
});

for (var i = 0; i < 10; i++) {
  channel.publish('welcome.' + i, 'hello world!');
}

unsubscribe();
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore, documentation, cleanup

## Motivation and Context
It's needed for events that should only happen once.

## How Has This Been Tested?
A bunch of unit tests are added

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
