### PR TITLE
reverse params

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Use the `emit` and `on` methods, just like a regular event emitter.
 ```js
 var channel = new Bus();
 
-channel.on('metrics.#', function (topic, msg) {
-  console.log(topic, msg);
+channel.on('metrics.#', function (msg) {
+  console.log(msg);
 });
 
 channel.emit('metrics.page.loaded', 'hello world');
@@ -35,9 +35,17 @@ channel.emit('metrics.page.loaded', 'hello world');
 In imitation of Postal.js, use the returned function to stop the events.
 
 ```js
-var off = channel.on('page.load.justOnce', function (topic, msg) {
-  console.log(topic, msg);
+var off = channel.on('page.load.justOnce', function (msg) {
+  console.log(msg);
   off();
+});
+```
+
+Also in imitation of Postal.js, use the second parameter to get the topic that triggered the event.
+
+```js
+var off = channel.on('page.ad.*.filled', function (msg, meta) {
+  console.log(meta.topic + 'just happened');
 });
 ```
 
@@ -46,8 +54,8 @@ If you like the pub/sub model better, we've aliased `subscribe` and `publish` as
 ```js
 var channel = new Bus();
 
-channel.subscribe('metrics.#', function (topic, msg) {
-  console.log(topic, msg);
+channel.subscribe('metrics.#', function (msg) {
+  console.log(msg);
 });
 
 channel.publish('metrics.page.loaded', 'hello world');
@@ -56,8 +64,8 @@ channel.publish('metrics.page.loaded', 'hello world');
 And of course to unsubscribe, use the returned function:
 
 ```js
-var unsubscribe = channel.subscribe('#', function (topic, msg) {
-  console.log(Date.now(), topic, msg);
+var unsubscribe = channel.subscribe('#', function (msg) {
+  console.log(Date.now(), msg);
 });
 
 for (var i = 0; i < 10; i++) {
@@ -78,14 +86,14 @@ Supports same wildcards as Postal.js, such as:
 #### Zero or more words using `#`
 
 ```js
-channel.subscribe('#.changed', function (topic, msg) {
+channel.subscribe('#.changed', function (msg) {
   // ...
 });
 channel.emit('what.has.changed', event);
 ```
 
 ```js
-channel.subscribe('metrics.#.changed', function (topic, msg) {
+channel.subscribe('metrics.#.changed', function (msg) {
   // ...
 });
 channel.emit('metrics.something.important.has.changed', event);
@@ -94,7 +102,7 @@ channel.emit('metrics.something.important.has.changed', event);
 #### Single word using `*`
 
 ```js
-channel.subscribe('ads.slot.*.filled', function (topic, msg) {
+channel.subscribe('ads.slot.*.filled', function (msg) {
   // ...
 });
 channel.emit('ads.slot.post-nav.filled', {data, msg});

--- a/index.js
+++ b/index.js
@@ -129,13 +129,15 @@ var Bus = (function () {
     }
 
     function emit(topicStr, message) {
-      historyCache.push([topicStr, Date.now()]);
+      var ts = Date.now();
+      historyCache.push([topicStr, ts]);
       var list = getCachedList(topicStr, head, emitCache);
+      var meta = {topic: topicStr};
 
       for (var i = 0; i < list.length; i++) {
         var fn = list[i];
         for (var j = 0; j < fn.length; j++) {
-          fn[j](topicStr, message);
+          fn[j](message, meta);
         }
       }
     }

--- a/index.test.js
+++ b/index.test.js
@@ -22,7 +22,7 @@ describe('exact matches', function () {
     sinon.assert.called(spy2);
   });
 
-  it('sends message', function () {
+  it('can send strings as message', function () {
     var bus = new Bus();
     var expected = 'b';
     var spy = sinon.spy();
@@ -30,7 +30,29 @@ describe('exact matches', function () {
     bus.on('a', spy);
     bus.emit('a', expected);
 
-    sinon.assert.calledWith(spy, sinon.match.any, expected);
+    sinon.assert.calledWith(spy, expected);
+  });
+
+  it('can send objects without changing reference', function () {
+    var bus = new Bus();
+    var expected = {};
+    var spy = sinon.spy();
+
+    bus.on('a', spy);
+    bus.emit('a', expected);
+
+    sinon.assert.calledWith(spy, expected);
+  });
+
+  it('can send objects without changing reference', function () {
+    var bus = new Bus();
+    var expected = {topic: 'a'};
+    var spy = sinon.spy();
+
+    bus.on('a', spy);
+    bus.emit('a', {});
+
+    sinon.assert.calledWith(spy, sinon.match.any, sinon.match(expected));
   });
 });
 


### PR DESCRIPTION
Based on feedback, the first parameter in an event is pretty useless, so we're going to move things around a bit.  This is a breaking change, but not too many people are using the library yet.

## Description
This is now the order of the parameters in an event:

```js
var off = channel.on('page.ad.*.filled', function (msg, meta) {
  console.log(meta.topic + 'just happened');
});
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore, documentation, cleanup

## Motivation and Context
It is a pain to ignore the first parameter all the time.  Also, this now matches Postaljs even more.

## How Has This Been Tested?
New unit tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
