### PR TITLE
add message history feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [x.y.z]: https://github.com/CondeNast/tk/compare/1.0.0...x.y.z
 -->
 
+## [0.3.0] - 2019-07-23
+- **Added** History now contains serialized message payload
+
 ## [Unreleased]
 - Initial Release
 

--- a/README.md
+++ b/README.md
@@ -129,17 +129,17 @@ var history = channel.history('metrics.component.*.render.*');
 ```
 
 The format is an array of arrays.  For example:
-```json
+```js
 [
-  ["ads.slot.post-nav.filled", 1515714470550],
-  ["ads.slot.side-rail.filled", 1515714470559],
-  ["ads.slot.instream-banner-0.filled", 1515714500268],
-  ["metrics.component.absdf2324.render.start", 1515714782584],
-  ["metrics.component.absdf2324.render.end", 1515714790507],
+  ["ads.slot.post-nav.filled", 1515714470550, '{"data":1,"msg":2}'],
+  ["ads.slot.side-rail.filled", 1515714470559, '{"thing":1,"stuff":2}'],
+  ["ads.slot.instream-banner-0.filled", 1515714500268, '{"a":1,"b":2}'],
+  ["metrics.component.absdf2324.render.start", 1515714782584, '{"a":"a", "b":"b"}'],
+  ["metrics.component.absdf2324.render.end", 1515714790507, '{"a":"a", "b":"b"}'],
 ]
 ```
 
-Only the topic and the timestamp of each event is stored.  We don't store the message/payload in the history to prevent potential memory leaks and scoping issues.
+Only the topic and the timestamp of each event is stored.  We don't store the raw message/payload in the history to prevent potential memory leaks and scoping issues, instead storing a serialized version of the payload.
 
 These events are stored in a ring buffer, so old events will be dropped from the history once it reaches a certain size.  The history size is current set to a maximum of 9999 events.
 

--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ var Bus = (function () {
 
     function emit(topicStr, message) {
       var ts = Date.now();
-      historyCache.push([topicStr, ts]);
+      historyCache.push([topicStr, ts, JSON.stringify(message)]);
       var list = getCachedList(topicStr, head, emitCache);
       var meta = {topic: topicStr};
 

--- a/index.test.js
+++ b/index.test.js
@@ -406,6 +406,17 @@ describe('history', function () {
 
     sinon.assert.called(spy);
   });
+
+  it('get serialized object from history', function () {
+    var bus = new Bus();
+    var spy = sinon.spy();
+
+    var data = {hello: "world"};
+
+    bus.on('a', spy);
+    bus.emit('a', data);
+    expect(bus.history('a')[0][2]).to.equal(JSON.stringify(data));
+  });
 });
 
 describe('Ring', function () {
@@ -508,5 +519,3 @@ describe('Ring', function () {
     expect(ring.asArray()).to.deep.equal(['h', 'i', 'j', 'k', 'l']);
   });
 });
-
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@condenast/quick-bus",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A tiny and fast event bus with AMQP and Postal.js-like functionality",
   "main": "index.min.js",
   "scripts": {


### PR DESCRIPTION
## Description
This adds the ability to read stringified message events from the history api, which previously only returned a timestamp.

## Types of changes
- [ ] Adds stringified message event to history
- [ ] Version bump to 0.3.0

## Motivation and Context
Developers wanted to be able to look at the complete event history that happened in the past, not just the fact that an event happened. Events are serialized to freeze them at this point in time.

## How Has This Been Tested?
New test added.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
